### PR TITLE
feat: lock unit test run to 2.8.12 composer

### DIFF
--- a/.github/workflows/phpunit_test_runner.yml
+++ b/.github/workflows/phpunit_test_runner.yml
@@ -12,6 +12,7 @@ env:
   GITHUB_RUN_ATTEMPT: ${{ github.event.client_payload.GITHUB_RUN_ATTEMPT }}
   GITHUB_PULL_REQUEST: ${{ github.event.client_payload.GITHUB_PULL_REQUEST }}
   ADDITIONAL_MODULES: ${{ github.event.client_payload.additional_modules || '' }}
+  COMPOSER_VERSION: 2.8.12
 
 
 run-name: >


### PR DESCRIPTION
Not actually sure if this is the right place to do this or not, but we need to get composer installing correctly for v10 CI builds.